### PR TITLE
fix(#2) build on macosx on Mojave

### DIFF
--- a/wrk2.rb
+++ b/wrk2.rb
@@ -7,6 +7,9 @@ class Wrk2 < Formula
   depends_on "openssl"
 
   def install
+    # Per https://luajit.org/install.html: If MACOSX_DEPLOYMENT_TARGET
+    # is not set then it's forced to 10.4, which breaks compile on Mojave.
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
     system "make"
     mv "wrk", "wrk2"
     bin.install "wrk2"


### PR DESCRIPTION
Per https://luajit.org/install.html: If MACOSX_DEPLOYMENT_TARGET is not set then it's forced to 10.4, which breaks compile on Mojave.

related to: https://github.com/Homebrew/homebrew-core/commit/f39c2dd50c252b40c83c8d4664bd449c9787fa1e